### PR TITLE
Django 1.8 support

### DIFF
--- a/sqlstacktrace/__init__.py
+++ b/sqlstacktrace/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 from django.conf import settings
 from .replacer import replace_call
@@ -6,7 +6,7 @@ from .replacer import replace_call
 
 SQL_STACKTRACE = settings.SQL_STACKTRACE if hasattr(settings, 'SQL_STACKTRACE') else False
 if SQL_STACKTRACE:
-    from django.db.backends import BaseDatabaseWrapper
+    from django.db.backends.base.base import BaseDatabaseWrapper
     from .stacktracecursor import StacktraceCursorWrapper
 
     @replace_call(BaseDatabaseWrapper.cursor)


### PR DESCRIPTION
Fixed BaseDatabaseWrapper import that fails on Django 1.8+.

The change is not backwards compatible with older versions of Django so it warrants a minor version bump to 0.3.
